### PR TITLE
Adds travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: c
+
+sudo: false
+
+env:
+  global:
+    - LUAROCKS=2.2.1
+  matrix:
+    - LUA=lua5.1
+    - LUA=lua5.2
+    - LUA=lua5.3
+    - LUA=luajit     # latest stable version (2.0.3)
+    - LUA=luajit2.0  # current head of 2.0 branch
+    - LUA=luajit2.1  # current head of 2.1 branch
+
+before_install:
+  - source .travis/setenv_lua.sh
+
+script: 
+  - lua valua-test.lua
+
+after_success:
+
+notifications:
+  email:
+    on_success: change
+    on_failure: always

--- a/.travis/platform.sh
+++ b/.travis/platform.sh
@@ -1,0 +1,15 @@
+if [ -z "${PLATFORM:-}" ]; then
+  PLATFORM=$TRAVIS_OS_NAME;
+fi
+
+if [ "$PLATFORM" == "osx" ]; then
+  PLATFORM="macosx";
+fi
+
+if [ -z "$PLATFORM" ]; then
+  if [ "$(uname)" == "Linux" ]; then
+    PLATFORM="linux";
+  else
+    PLATFORM="macosx";
+  fi;
+fi

--- a/.travis/setenv_lua.sh
+++ b/.travis/setenv_lua.sh
@@ -1,0 +1,3 @@
+export PATH=${PATH}:$HOME/.lua:$HOME/.local/bin:${TRAVIS_BUILD_DIR}/install/luarocks/bin
+bash .travis/setup_lua.sh
+eval `$HOME/.lua/luarocks path`

--- a/.travis/setup_lua.sh
+++ b/.travis/setup_lua.sh
@@ -1,0 +1,122 @@
+#! /bin/bash
+
+# A script for setting up environment for travis-ci testing.
+# Sets up Lua and Luarocks.
+# LUA must be "lua5.1", "lua5.2" or "luajit".
+# luajit2.0 - master v2.0
+# luajit2.1 - master v2.1
+
+set -eufo pipefail
+
+LUAJIT_BASE="LuaJIT-2.0.3"
+
+source .travis/platform.sh
+
+LUA_HOME_DIR=$TRAVIS_BUILD_DIR/install/lua
+
+LR_HOME_DIR=$TRAVIS_BUILD_DIR/install/luarocks
+
+mkdir $HOME/.lua
+
+LUAJIT="no"
+
+if [ "$PLATFORM" == "macosx" ]; then
+  if [ "$LUA" == "luajit" ]; then
+    LUAJIT="yes";
+  fi
+  if [ "$LUA" == "luajit2.0" ]; then
+    LUAJIT="yes";
+  fi
+  if [ "$LUA" == "luajit2.1" ]; then
+    LUAJIT="yes";
+  fi;
+elif [ "$(expr substr $LUA 1 6)" == "luajit" ]; then
+  LUAJIT="yes";
+fi
+
+mkdir -p "$LUA_HOME_DIR"
+
+if [ "$LUAJIT" == "yes" ]; then
+
+  if [ "$LUA" == "luajit" ]; then
+    curl http://luajit.org/download/$LUAJIT_BASE.tar.gz | tar xz;
+  else
+    git clone http://luajit.org/git/luajit-2.0.git $LUAJIT_BASE;
+  fi
+
+  cd $LUAJIT_BASE
+
+  if [ "$LUA" == "luajit2.1" ]; then
+    git checkout v2.1;
+  fi
+
+  make && make install PREFIX="$LUA_HOME_DIR"
+
+  if [ "$LUA" == "luajit2.1" ]; then
+    ln -s $LUA_HOME_DIR/bin/luajit-2.1.0-alpha $HOME/.lua/luajit
+    ln -s $LUA_HOME_DIR/bin/luajit-2.1.0-alpha $HOME/.lua/lua;
+  else
+    ln -s $LUA_HOME_DIR/bin/luajit $HOME/.lua/luajit
+    ln -s $LUA_HOME_DIR/bin/luajit $HOME/.lua/lua;
+  fi;
+
+else
+
+  if [ "$LUA" == "lua5.1" ]; then
+    curl http://www.lua.org/ftp/lua-5.1.5.tar.gz | tar xz
+    cd lua-5.1.5;
+  elif [ "$LUA" == "lua5.2" ]; then
+    curl http://www.lua.org/ftp/lua-5.2.4.tar.gz | tar xz
+    cd lua-5.2.4;
+  elif [ "$LUA" == "lua5.3" ]; then
+    curl http://www.lua.org/ftp/lua-5.3.0.tar.gz | tar xz
+    cd lua-5.3.0;
+  fi
+
+  make $PLATFORM
+  make INSTALL_TOP="$LUA_HOME_DIR" install;
+
+  ln -s $LUA_HOME_DIR/bin/lua $HOME/.lua/lua
+  ln -s $LUA_HOME_DIR/bin/luac $HOME/.lua/luac;
+
+fi
+
+cd $TRAVIS_BUILD_DIR
+
+lua -v
+
+LUAROCKS_BASE=luarocks-$LUAROCKS
+
+curl --location http://luarocks.org/releases/$LUAROCKS_BASE.tar.gz | tar xz
+
+cd $LUAROCKS_BASE
+
+if [ "$LUA" == "luajit" ]; then
+  ./configure --lua-suffix=jit --with-lua-include="$LUA_HOME_DIR/include/luajit-2.0" --prefix="$LR_HOME_DIR";
+elif [ "$LUA" == "luajit2.0" ]; then
+  ./configure --lua-suffix=jit --with-lua-include="$LUA_HOME_DIR/include/luajit-2.0" --prefix="$LR_HOME_DIR";
+elif [ "$LUA" == "luajit2.1" ]; then
+  ./configure --lua-suffix=jit --with-lua-include="$LUA_HOME_DIR/include/luajit-2.1" --prefix="$LR_HOME_DIR";
+else
+  ./configure --with-lua="$LUA_HOME_DIR" --prefix="$LR_HOME_DIR"
+fi
+
+make build && make install
+
+ln -s $LR_HOME_DIR/bin/luarocks $HOME/.lua/luarocks
+
+cd $TRAVIS_BUILD_DIR
+
+luarocks --version
+
+rm -rf $LUAROCKS_BASE
+
+if [ "$LUAJIT" == "yes" ]; then
+  rm -rf $LUAJIT_BASE;
+elif [ "$LUA" == "lua5.1" ]; then
+  rm -rf lua-5.1.5;
+elif [ "$LUA" == "lua5.2" ]; then
+  rm -rf lua-5.2.4;
+elif [ "$LUA" == "lua5.3" ]; then
+  rm -rf lua-5.3.0;
+fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ##Valua - Validation for Lua
 
+[![Build Status](https://travis-ci.org/Etiene/valua.svg?branch=master)](https://travis-ci.org/Etiene/valua)
+
 A module for making chained validations. Create your objects, append your tests, use and reuse it!
 
 Originally bundled with Sailor MVC Web Framework, now released as a separated module.

--- a/valua-0.2.1-2.rockspec
+++ b/valua-0.2.1-2.rockspec
@@ -1,0 +1,23 @@
+package = "Valua"
+version = "0.2.1-1"
+source = {
+   url = "git://github.com/Etiene/valua",
+   tag = "v0.2.1"
+}
+description = {
+   summary = "Validation for Lua!",
+   detailed = [[
+      This module provides tools for validating values, very useful in forms, but also usable elsewhere. It works in appended chains. Create a new validation object and start chaining your test functions.
+   ]],
+   homepage = "https://github.com/Etiene/valua", 
+   license = "MIT"
+}
+dependencies = {
+   "lua >= 5.1, < 5.4"
+}
+build = {
+   type = "builtin",
+   modules = {
+      ["valua"] = "valua.lua",
+   }
+}


### PR DESCRIPTION
Adds Travis-ci integration. It runs the tests on Lua 5.1, 5.2, 5.3, LuaJIT 2.0.3, latest 2.0 and latest 2.1.
For steps to enable the integration, please take a look at [this article](http://blog.separateconcerns.com/2015-03-08-travis-lua.html).

It also includes a new rockspec since the tests showed that Lua 5.3 is also supported :)